### PR TITLE
Update versions for postgresql/postgis

### DIFF
--- a/installation-guide/server.rst
+++ b/installation-guide/server.rst
@@ -13,8 +13,8 @@ Server installation
 
 Server side software components are:
 
-* `PostgreSQL <https://postgresql.org/>`_ (> 9.3)
-* `PostGIS <https://postgis.net/>`_, the spatial extension (> 2.1)
+* `PostgreSQL <https://postgresql.org/>`_ (>= 9.6)
+* `PostGIS <https://postgis.net/>`_, the spatial extension (> 2.3)
 * `Python <https://www.python.org/>`_, for installation and update (> 3.5)
 * `PUM <https://github.com/opengisch/pum>`_ for upgrade
 


### PR DESCRIPTION
Update require postgresql (needed since 1.3.2) and postgis version (versions < 2.3 are EOL)